### PR TITLE
artist-popup-description-margin-bottom-added

### DIFF
--- a/src/pages/Artists/ArtistCard.jsx
+++ b/src/pages/Artists/ArtistCard.jsx
@@ -47,7 +47,9 @@ const ArtistCard = ({ artist }) => {
       <Modal open={open} onClose={handleClose}>
         <Box sx={style}>
           <Typography variant="h6">{artist.name}</Typography>
-          <Typography variant="body1">{artist.fullDescription}</Typography>
+          <Typography variant="body1" sx={{ marginBottom: "10px" }}>
+            {artist.fullDescription}
+            </Typography>
           <Button onClick={handleOrder} variant="contained" color="primary">
             Заказать
           </Button>


### PR DESCRIPTION
Увеличен отступ во всплывающем окне артиста между описанием и кнопкой "Заказать" на 10px:
![Снимок экрана 2024-10-09 143115](https://github.com/user-attachments/assets/488640ef-c2d5-45b2-a64d-e6888a259865)

